### PR TITLE
Update joint limits

### DIFF
--- a/config/joint_limits.yaml
+++ b/config/joint_limits.yaml
@@ -1,4 +1,10 @@
 # joint_limits.yaml allows the dynamics properties specified in the URDF to be overwritten or augmented as needed
+
+# For beginners, we downscale velocity and acceleration limits.
+# You can always specify higher scaling factors (<= 1.0) in your motion requests.  # Increase the values below to 1.0 to always move at maximum speed.
+default_velocity_scaling_factor: 0.1
+default_acceleration_scaling_factor: 0.1
+
 # Specific joint properties can be changed with the keys [max_position, min_position, max_velocity, max_acceleration]
 # Joint limits can be turned off with [has_velocity_limits, has_acceleration_limits]
 
@@ -8,6 +14,16 @@
 # max_jerk = (max_acceleration - min_acceleration) / 0.001
 
 joint_limits:
+  panda_finger_joint1:
+    has_velocity_limits: true
+    max_velocity: 0.1
+    has_acceleration_limits: false
+    max_acceleration: 0
+  panda_finger_joint2:
+    has_velocity_limits: true
+    max_velocity: 0.1
+    has_acceleration_limits: false
+    max_acceleration: 0
   panda_joint1:
     has_velocity_limits: true
     max_velocity: 2.1750
@@ -43,13 +59,4 @@ joint_limits:
     max_velocity: 2.6100
     has_acceleration_limits: true
     max_acceleration: 5
-  panda_finger_joint1:
-    has_velocity_limits: true
-    max_velocity: 0.1
-    has_acceleration_limits: false
-    max_acceleration: 0
-  panda_finger_joint2:
-    has_velocity_limits: true
-    max_velocity: 0.1
-    has_acceleration_limits: false
-    max_acceleration: 0
+

--- a/config/joint_limits.yaml
+++ b/config/joint_limits.yaml
@@ -1,55 +1,55 @@
 # joint_limits.yaml allows the dynamics properties specified in the URDF to be overwritten or augmented as needed
-
-# For beginners, we downscale velocity and acceleration limits.
-# You can always specify higher scaling factors (<= 1.0) in your motion requests.  # Increase the values below to 1.0 to always move at maximum speed.
-default_velocity_scaling_factor: 0.1
-default_acceleration_scaling_factor: 0.1
-
 # Specific joint properties can be changed with the keys [max_position, min_position, max_velocity, max_acceleration]
 # Joint limits can be turned off with [has_velocity_limits, has_acceleration_limits]
+
+# As MoveIt! does not support jerk limits, the acceleration limits provided here are the highest values that guarantee
+# that no jerk limits will be violated. More precisely, applying Euler differentiation in the worst case (from min accel
+# to max accel in 1 ms) the acceleration limits are the ones that satisfy
+# max_jerk = (max_acceleration - min_acceleration) / 0.001
+
 joint_limits:
+  panda_joint1:
+    has_velocity_limits: true
+    max_velocity: 2.1750
+    has_acceleration_limits: true
+    max_acceleration: 3.75
+  panda_joint2:
+    has_velocity_limits: true
+    max_velocity: 2.1750
+    has_acceleration_limits: true
+    max_acceleration: 1.875
+  panda_joint3:
+    has_velocity_limits: true
+    max_velocity: 2.1750
+    has_acceleration_limits: true
+    max_acceleration: 2.5
+  panda_joint4:
+    has_velocity_limits: true
+    max_velocity: 2.1750
+    has_acceleration_limits: true
+    max_acceleration: 3.125
+  panda_joint5:
+    has_velocity_limits: true
+    max_velocity: 2.6100
+    has_acceleration_limits: true
+    max_acceleration: 3.75
+  panda_joint6:
+    has_velocity_limits: true
+    max_velocity: 2.6100
+    has_acceleration_limits: true
+    max_acceleration: 5
+  panda_joint7:
+    has_velocity_limits: true
+    max_velocity: 2.6100
+    has_acceleration_limits: true
+    max_acceleration: 5
   panda_finger_joint1:
     has_velocity_limits: true
-    max_velocity: 0.2
+    max_velocity: 0.1
     has_acceleration_limits: false
     max_acceleration: 0
   panda_finger_joint2:
     has_velocity_limits: true
-    max_velocity: 0.2
-    has_acceleration_limits: false
-    max_acceleration: 0
-  panda_joint1:
-    has_velocity_limits: true
-    max_velocity: 2.175
-    has_acceleration_limits: false
-    max_acceleration: 0
-  panda_joint2:
-    has_velocity_limits: true
-    max_velocity: 2.175
-    has_acceleration_limits: false
-    max_acceleration: 0
-  panda_joint3:
-    has_velocity_limits: true
-    max_velocity: 2.175
-    has_acceleration_limits: false
-    max_acceleration: 0
-  panda_joint4:
-    has_velocity_limits: true
-    max_velocity: 2.175
-    has_acceleration_limits: false
-    max_acceleration: 0
-  panda_joint5:
-    has_velocity_limits: true
-    max_velocity: 2.61
-    has_acceleration_limits: false
-    max_acceleration: 0
-  panda_joint6:
-    has_velocity_limits: true
-    max_velocity: 2.61
-    has_acceleration_limits: false
-    max_acceleration: 0
-  panda_joint7:
-    has_velocity_limits: true
-    max_velocity: 2.61
+    max_velocity: 0.1
     has_acceleration_limits: false
     max_acceleration: 0


### PR DESCRIPTION
This pull request updates the `joint_limits.yaml` file that was created by the MSA were modified such that no jerk limits will be violated. This was done by adding acceleration limits, since MoveIt does not yet support jerk limits.