### PR TITLE
Removes kinematics params from trajopt benchmark

### DIFF
--- a/launch/run_benchmark_trajopt.launch
+++ b/launch/run_benchmark_trajopt.launch
@@ -15,7 +15,6 @@
 
   <!-- Start Benchmark Executable -->
   <node name="$(anon moveit_benchmark)" pkg="moveit_ros_benchmarks" type="moveit_run_benchmark" args="$(arg cfg) --benchmark-planners" respawn="false" output="screen">
-    <rosparam command="load" file="$(find moveit_resources_panda_moveit_config)/config/kinematics.yaml"/>
     <rosparam command="load" file="$(find moveit_resources_panda_moveit_config)/config/trajopt_planning.yaml"/>
   </node>
 


### PR DESCRIPTION
This pull request removes the kinematics from the `run_benchmark_trajopt.launch` launch file since I think they are already handled in `planning_context.launch` file:

https://github.com/rhaschke/panda_moveit_config/blob/4c390ac0b2370aa5015e1f84c74a2818deaf9330/launch/planning_context.launch#L22-L23