### PR TITLE
Split real and simulated controller config files

### DIFF
--- a/config/moveit_controllers.yaml
+++ b/config/moveit_controllers.yaml
@@ -1,0 +1,22 @@
+ros_control_namespace: $(arg robot_ns)
+controller_list:
+  - name: panda_arm_controller
+    action_ns: follow_joint_trajectory
+    type: FollowJointTrajectory
+    default: true
+    joints:
+      - panda_joint1
+      - panda_joint2
+      - panda_joint3
+      - panda_joint4
+      - panda_joint5
+      - panda_joint6
+      - panda_joint7
+
+  - name: franka_gripper
+    action_ns: gripper_action
+    type: GripperCommand
+    default: true
+    joints:
+      - panda_finger_joint1
+      - panda_finger_joint2

--- a/config/real_ros_controllers.yaml
+++ b/config/real_ros_controllers.yaml
@@ -1,0 +1,28 @@
+# NOTE: Here the position controller is used since @frankaemika does not provide PID
+# gains for effort controllers on the real robot.
+panda_arm_controller:
+  type: position_controllers/JointTrajectoryController
+  joints:
+    - panda_joint1
+    - panda_joint2
+    - panda_joint3
+    - panda_joint4
+    - panda_joint5
+    - panda_joint6
+    - panda_joint7
+  constraints:
+    goal_time: 0.5
+    panda_joint1:
+      goal: 0.05
+    panda_joint2:
+      goal: 0.05
+    panda_joint3:
+      goal: 0.05
+    panda_joint4:
+      goal: 0.05
+    panda_joint5:
+      goal: 0.05
+    panda_joint6:
+      goal: 0.05
+    panda_joint7:
+      goal: 0.05

--- a/config/ros_controllers.yaml
+++ b/config/ros_controllers.yaml
@@ -9,19 +9,19 @@ panda_arm_controller:
     - panda_joint6
     - panda_joint7
   gains:
-    panda_joint1: { p: 12000, d: 50, i: 0.0, i_clamp: 10000 }
-    panda_joint2: { p: 30000, d: 100, i: 0.02, i_clamp: 10000 }
-    panda_joint3: { p: 18000, d: 50, i: 0.01, i_clamp: 1 }
-    panda_joint4: { p: 18000, d: 70, i: 0.01, i_clamp: 10000 }
-    panda_joint5: { p: 12000, d: 70, i: 0.01, i_clamp: 1 }
-    panda_joint6: { p: 7000, d: 50, i: 0.01, i_clamp: 1 }
-    panda_joint7: { p: 2000, d: 20, i: 0.0, i_clamp: 1 }
+    panda_joint1: { p: 600, d: 30, i: 0 }
+    panda_joint2: { p: 600, d: 30, i: 0 }
+    panda_joint3: { p: 600, d: 30, i: 0 }
+    panda_joint4: { p: 600, d: 30, i: 0 }
+    panda_joint5: { p: 250, d: 10, i: 0 }
+    panda_joint6: { p: 150, d: 10, i: 0 }
+    panda_joint7: { p:  50, d:  5, i: 0 }
 
-panda_hand_controller:
-  type: effort_controllers/JointTrajectoryController
-  joints:
-      - panda_finger_joint1
-      - panda_finger_joint2
-  gains:
-      panda_finger_joint1: { p: 1000, d: 3.0, i: 0, i_clamp: 1 }
-      panda_finger_joint2: { p: 1000, d: 1.0, i: 0, i_clamp: 1 }
+# panda_hand_controller:
+#   type: effort_controllers/JointTrajectoryController
+#   joints:
+#       - panda_finger_joint1
+#       - panda_finger_joint2
+#   gains:
+#       panda_finger_joint1: { p: 1000, d: 3.0, i: 0, i_clamp: 1 }
+#       panda_finger_joint2: { p: 1000, d: 1.0, i: 0, i_clamp: 1 }

--- a/launch/franka_gazebo.launch
+++ b/launch/franka_gazebo.launch
@@ -23,10 +23,14 @@
     <arg name="headless" value="$(eval not arg('gazebo_gui'))" />
     <arg name="paused" value="$(arg paused)"/>
     <arg name="use_gripper" default="$(arg load_gripper)"/>
-    <arg name="transmission" value="hardware_interface/PositionJointInterface"/>
   </include>
 
   <group ns="panda">
+    <!-- Load simulation controllers -->
+    <include file="$(dirname)/ros_controllers.launch">
+      <arg name="gazebo" value="true"/>
+    </include>
+
     <!-- Run the main MoveIt executable without trajectory execution (we do not have controllers configured by default) -->
     <include file="$(dirname)/move_group.launch">
       <arg name="allow_trajectory_execution" value="true" />
@@ -37,6 +41,7 @@
       <arg name="load_gripper" value="$(arg load_gripper)" />
       <!-- robot description is loaded by franka_gazebo/panda.launch, to enable Gazebo features -->
       <arg name="load_robot_description" value="false" />
+      <arg name="robot_ns" value="/panda" />
     </include>
 
     <!-- Run Rviz and load the default config to see the state of the move_group node -->

--- a/launch/move_group.launch
+++ b/launch/move_group.launch
@@ -18,6 +18,7 @@
   <arg name="execution_type" default="interpolate"/> <!-- set to 'last point' to skip intermediate trajectory in fake execution -->
   <arg name="max_safe_path_cost" default="1"/>
   <arg name="publish_monitored_planning_scene" default="true"/>
+  <arg name="robot_ns" default="" />
 
   <arg name="capabilities" default=""/>
   <arg name="disable_capabilities" default=""/>
@@ -78,6 +79,7 @@
     <arg name="moveit_manage_controllers" value="true" />
     <arg name="moveit_controller_manager" value="$(arg moveit_controller_manager)" />
     <arg name="execution_type" value="$(arg execution_type)" />
+    <arg name="robot_ns" value="$(arg robot_ns)" />
   </include>
 
   <!-- Sensors Functionality -->

--- a/launch/panda_moveit.launch
+++ b/launch/panda_moveit.launch
@@ -6,5 +6,6 @@
 
   <include file="$(dirname)/move_group.launch">
     <arg name="load_gripper" value="$(arg load_gripper)" />
+    <arg name="moveit_controller_manager" value="ros_control" />
   </include>
 </launch>

--- a/launch/ros_control_moveit_controller_manager.launch.xml
+++ b/launch/ros_control_moveit_controller_manager.launch.xml
@@ -1,4 +1,9 @@
 <launch>
+	<arg name="robot_ns" default="" />
+
 	<!-- Define MoveIt controller manager plugin -->
 	<param name="moveit_controller_manager" value="moveit_ros_control_interface::MoveItControllerManager" />
+
+	<!-- Load action controller definitions -->
+	<rosparam subst_value="true" file="$(find panda_moveit_config)/config/moveit_controllers.yaml" />
 </launch>

--- a/launch/ros_controllers.launch
+++ b/launch/ros_controllers.launch
@@ -1,8 +1,10 @@
 <?xml version="1.0"?>
 <launch>
+  <arg name="gazebo" default="false" /> <!--Set to 'true' when you want to use the simulation controllers-->
 
   <!-- Load controller configurations from YAML file(s) to parameter server -->
-  <rosparam file="$(find panda_moveit_config)/config/ros_controllers.yaml" />
+  <rosparam if="$(arg gazebo)" file="$(find panda_moveit_config)/config/ros_controllers.yaml" />
+  <rosparam unless="$(arg gazebo)" file="$(find panda_moveit_config)/config/real_ros_controllers.yaml" />
 
   <!-- Load joint-trajectory controller into ROS controller_manager -->
   <node name="trajectory_controller_spawner" pkg="controller_manager" type="spawner" respawn="false" output="screen" args="panda_arm_controller" />

--- a/launch/trajectory_execution.launch.xml
+++ b/launch/trajectory_execution.launch.xml
@@ -4,6 +4,7 @@
   <!-- Define moveit controller manager plugin: fake, simple, or ros_control -->
   <arg name="moveit_controller_manager" />
   <arg name="execution_type" default="interpolate" />
+  <arg name="robot_ns" default="" />
 
   <!-- Flag indicating whether MoveIt is allowed to load/unload  or switch controllers -->
   <arg name="moveit_manage_controllers" default="true"/>


### PR DESCRIPTION
This pull request makes sure that the real and simulated controllers are in seperate configuration files. This was done since the PID gains that work in the simulation does not work on the real robot. 

I converted this pull request to a draft as I'm not yet happy with it:
- There should be an easier way to set the `ros_control_namespace` without passing it through all launch files. 
- For the simulation, we might want to change to using an `effort_controllers/JointTrajectoryController` for the fingers if [franka_ros/pull/180](https://github.com/frankaemika/franka_ros/pull/180) and [franka_ros/pull/173](https://github.com/frankaemika/franka_ros/pull/173) are not successfully merged. This will however further complicate the codebase.