### PR TITLE
fix 'moveit_ros_control_interface' gazebo arm control

### DIFF
--- a/config/gazebo_moveit_controllers.yaml
+++ b/config/gazebo_moveit_controllers.yaml
@@ -1,0 +1,44 @@
+ros_control_namespace: /panda
+# NOTE: REMOVE JOINTS TO SEE THAT THE CONTROLLER LIST IS IGNORED.
+controller_list:
+  - name: panda_arm_controller
+    action_ns: follow_joint_trajectory
+    type: FollowJointTrajectory
+    default: true
+    joints:
+      - panda_joint1
+      - panda_joint2
+      - panda_joint3
+      - panda_joint4
+      - panda_joint5
+      - panda_joint6
+      - panda_joint7
+  - name: franka_gripper
+    action_ns: gripper_action
+    type: GripperCommand
+    default: true
+    joints:
+      - panda_finger_joint1
+      - panda_finger_joint2
+
+# NOTE: Wrong controller_list
+# controller_list:
+#   - name: franka_gripper
+#     action_ns: follow_joint_trajectory
+#     type: FollowJointTrajectory
+#     default: true
+#     joints:
+#       - panda_joint1
+#       - panda_joint2
+#       - panda_joint3
+#       - panda_joint4
+#       - panda_joint5
+#       - panda_joint6
+#       - panda_joint7
+#   - name: panda_arm_controller
+#     action_ns: gripper_action
+#     type: GripperCommand
+#     default: true
+#     joints:
+#       - panda_finger_joint1
+#       - panda_finger_joint2

--- a/launch/franka_gazebo.launch
+++ b/launch/franka_gazebo.launch
@@ -3,7 +3,7 @@
   <arg name="pipeline" default="ompl" />
 
   <!-- Franka demo controller to use -->
-  <arg name="controller" default="cartesian_impedance_example_controller" />
+  <arg name="controller" default=" " />
 
   <!-- By default we will load the gripper -->
   <arg name="load_gripper" default="true" />
@@ -21,6 +21,14 @@
   </include>
 
   <group ns="panda">
+    <!-- point the MoveItControllerManager to the right namespace-->
+    <!-- <param name="move_group/ros_control_namespace" type="string" value="/panda" /> -->
+
+    <!--NOTE: Left this here to show the controller list is ignored-->
+    <!-- <group ns="move_group">
+      <rosparam subst_value="true" file="$(find panda_moveit_config)/config/gazebo_moveit_controllers.yaml" />
+    </group> -->
+
     <include file="$(dirname)/demo.launch" pass_all_args="true">
       <!-- robot description is loaded by gazebo.launch, to enable Gazebo features -->
       <arg name="load_robot_description" value="false" />


### PR DESCRIPTION
This pull request shows how the `moveit_ros_control_interface::MoveItControllerManager` works. The most important thing is that you set the `ros_control_namespace` parameter within the `move_group` namespace. This controller manager however does not yet support the gripper action.