### PR TITLE
add automatic joint_trajectory_controller start

### DIFF
--- a/launch/franka_control.launch
+++ b/launch/franka_control.launch
@@ -3,6 +3,9 @@
   <!-- Launch real-robot control -->
   <include file="$(find franka_control)/launch/franka_control.launch" pass_all_args="true" />
 
+  <!-- Load joint-trajectory controller into ROS controller_manager -->
+  <node name="trajectory_controller_spawner" pkg="controller_manager" type="spawner" respawn="false" output="screen" args="joint_trajectory_controller" />
+
   <!-- as well as MoveIt demo -->
   <include file="$(dirname)/demo.launch" pass_all_args="true">
     <!-- robot description is loaded by gazebo.launch, to enable Gazebo features -->


### PR DESCRIPTION
This pull request makes sure that the joint_trajectory_controller is started automatically when the 'franka_control.launch' file is run.